### PR TITLE
fix hsl path error

### DIFF
--- a/downloader/tools/utils.py
+++ b/downloader/tools/utils.py
@@ -6,7 +6,7 @@ import argparse
 import re
 import shutil
 from pathlib import Path
-from urllib.parse import urlparse, unquote
+from urllib.parse import urlparse, unquote, urljoin
 import xml.etree.ElementTree as ET
 import logging
 import requests
@@ -140,9 +140,6 @@ def normalResponse(handler, resp, contentType = 'text/html'):
         resp = resp.encode('utf-8')
     handler.wfile.write(resp)
 
-def getBasePath(url):
-    return url.split('?', 1)[0].rsplit('/', 1)[0] + '/'
-
 def getFileName(url):
     return url.split('?', 1)[0].rsplit('/', 1)[-1]
 
@@ -205,14 +202,12 @@ def formatTime(value):
         return '%ds' % value
     else:
         return '%2dmin%02ds' % (value // 60, value % 60)
- 
+
 def filterHlsUrls(content, url = None):
     urls = re.findall(r'[^#"\s]+\.(?:ts|mp4)[^"\s]*', content, re.MULTILINE)
-
-    if len(urls) > 0 and not urls[0].startswith('http'):
-        basePath = getBasePath(url)
-        urls = list(map(lambda url: basePath + url, urls))
+    urls = [urljoin(url, u) for u in urls]
     return urls
+
 
 def tryFixSrtFile(srtFile):
     with open(srtFile, 'r+', encoding='utf-8', errors='ignore') as f:


### PR DESCRIPTION
https://video.twimg.com/ext_tw_video/1566002757923848192/pu/pl/462x480/g1pv3QLgyc_Y99Wn.m3u8?container=fmp4

```m3u8
#EXTM3U
#EXT-X-VERSION:6
#EXT-X-MEDIA-SEQUENCE:0
#EXT-X-TARGETDURATION:3
#EXT-X-PLAYLIST-TYPE:VOD
#EXT-X-MAP:URI="/ext_tw_video/1566002757923848192/pu/vid/0/0/462x480/-criYBRHZjA2HPch.mp4"
#EXTINF:3.000,
/ext_tw_video/1566002757923848192/pu/vid/0/3000/462x480/wK8SSMXT4F1Xtbz7.m4s
#EXTINF:3.000,
/ext_tw_video/1566002757923848192/pu/vid/3000/6000/462x480/CryAYDTcfcB_XD2b.m4s
#EXTINF:3.000,
/ext_tw_video/1566002757923848192/pu/vid/6000/9000/462x480/H0bzl3PJdOT-8JPe.m4s
#EXTINF:3.000,
/ext_tw_video/1566002757923848192/pu/vid/9000/12000/462x480/oSs_OD_XjbmBn1hI.m4s
#EXTINF:2.200,
/ext_tw_video/1566002757923848192/pu/vid/12000/14200/462x480/1Gj-0OiFZufH4Cde.m4s
#EXT-X-ENDLIST
```
download with error

`Exception: GET https://video.twimg.com/ext_tw_video/1566002757923848192/pu/pl/462x480//ext_tw_video/1566002757923848192/pu/vid/0/0/462x480/-criYBRHZjA2HPch.mp4 http响应: 404错误`

the correct url is `https://video.twimg.com/ext_tw_video/1566002757923848192/pu/vid/0/0/462x480/-criYBRHZjA2HPch.mp4`


fix with `urljoin`